### PR TITLE
fix: remove unicode control characters when attempting to parse JSON

### DIFF
--- a/luci-app-modemdata/htdocs/luci-static/resources/view/modem/modempreview.js
+++ b/luci-app-modemdata/htdocs/luci-static/resources/view/modem/modempreview.js
@@ -536,7 +536,7 @@ async function _readSignalsForIndex(idx, forceFresh) {
         res = await L.resolveDefault(fs.exec_direct('/usr/bin/md_modemmanager', [m.comm_port, m.network, m.forced_plmn || '-']));
 
       if (!res) return null;
-      let jsonraw = JSON.parse(res);
+      let jsonraw = JSON.parse(res.replace(/[\u0000-\u001F\u007F-\u009F]/g, ""));
       let arr = Object.values(jsonraw);
       if (!arr || arr.length < 3 || !arr[2]) return null;
 
@@ -1188,7 +1188,7 @@ function CreateModemMultiverse(modemTabs, sectionsxt) {
       })().then(function(res) {
         if (!res) return;
 
-        let jsonraw = JSON.parse(res);
+        let jsonraw = JSON.parse(res.replace(/[\u0000-\u001F\u007F-\u009F]/g, ""));
         let json = Object.values(jsonraw);
         if (!json || json.length < 3 || !json[0] || !json[1] || !json[2]) return;
 


### PR DESCRIPTION
Some operators appear to be inserting unicode control characters at the end of their name which then causes attempts to parse the raw text into proper JSON in modempreview.js to fail. As an example the author of this bugfix sees operator name reported as "evz\u001e\u0006".

This bugfix removes any unicode control characters from the raw text before attempting to parse it.